### PR TITLE
Get tests working

### DIFF
--- a/src/folder.rs
+++ b/src/folder.rs
@@ -236,7 +236,7 @@ impl Background for FolderScan {
 #[test]
 fn it_walks() {
     use crate::background::BackgroundHandle;
-    use crate::settings::Config;
+    use crate::config::Config;
 
     let gs = Config::default().globset().unwrap();
     let scanner = FolderScan::new("C:\\Games", gs);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-#![windows_subsystem = "windows"]
+#![cfg_attr(not(test), windows_subsystem = "windows")]
+#![cfg_attr(test, windows_subsystem = "console")]
 #![allow(non_snake_case)]
 
 mod backend;


### PR DESCRIPTION
Looks like the `settings` module was renamed to `config`

Also, sets the windows_subsystem to console when testing, so test results actually appear in the console.