### PR TITLE
Cargo Fmt, more Crossbeam channel, and Less Mutex

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -1,6 +1,6 @@
+use crossbeam_channel::{Receiver, RecvTimeoutError, TryRecvError};
 use std::panic::{catch_unwind, RefUnwindSafe};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, TryRecvError};
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
@@ -102,7 +102,7 @@ impl<T, S> BackgroundHandle<T, S> {
         T: Send + Sync + 'static,
         S: Send + Sync + Clone + 'static,
     {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = crossbeam_channel::unbounded();
         let control = ControlToken::new();
         let inner_control = control.clone();
 

--- a/src/compact.rs
+++ b/src/compact.rs
@@ -274,7 +274,10 @@ pub fn compress_file<P: AsRef<Path>>(path: P, compression: Compression) -> std::
     compress_file_handle(&file, compression)
 }
 
-pub fn compress_file_handle(file: &std::fs::File, compression: Compression) -> std::io::Result<bool> {
+pub fn compress_file_handle(
+    file: &std::fs::File,
+    compression: Compression,
+) -> std::io::Result<bool> {
     const LEN: usize = std::mem::size_of::<_WOF_EXTERNAL_INFO>()
         + std::mem::size_of::<_FILE_PROVIDER_EXTERNAL_INFO_V1>();
 

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -61,7 +61,7 @@ impl Background for BackgroundCompactor {
     type Output = ();
     type Status = ();
 
-    fn run(&self, control: &ControlToken<Self::Status>) -> Self::Output {
+    fn run(self, control: &ControlToken<Self::Status>) -> Self::Output {
         for file in &self.files_in {
             if control.is_cancelled_with_pause() {
                 break;

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,11 +1,11 @@
 use std::io;
-use std::path::PathBuf;
 use std::os::windows::fs::OpenOptionsExt;
+use std::path::PathBuf;
 
 use compresstimator::Compresstimator;
 use crossbeam_channel::{Receiver, Sender};
 use filetime::FileTime;
-use winapi::um::winnt::{FILE_WRITE_ATTRIBUTES, FILE_READ_DATA};
+use winapi::um::winnt::{FILE_READ_DATA, FILE_WRITE_ATTRIBUTES};
 
 use crate::background::Background;
 use crate::background::ControlToken;
@@ -51,7 +51,7 @@ fn handle_file(file: &PathBuf, compression: Option<Compression>) -> io::Result<b
     let _ = filetime::set_file_handle_times(
         &handle,
         Some(FileTime::from_last_access_time(&meta)),
-        Some(FileTime::from_last_modification_time(&meta))
+        Some(FileTime::from_last_modification_time(&meta)),
     );
 
     ret


### PR DESCRIPTION
1. Run cargo fmt
2. Use crossbeam channel everywhere instead of `std::mpsc`
3. Change `Background::run` to take self by value: this allowed for removing an unneeded mutex from folder scanning